### PR TITLE
Updated documentation: fix URI in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ curl "http://localhost:1337/restaurants"
 ```
 #### Get Restaurants by id
 ````
-curl "http://localhost:1337/restaurants/{3}"
+curl "http://localhost:1337/restaurants/<restaurant_id>"
 ````
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http://localhost:1337/restaurants/
 
 #### Get favorite restaurants
 ```
-http://localhost:1337/restaurants/?is_favorite=true
+http://localhost:1337/restaurants?is_favorite=true
 ```
 
 #### Get a restaurant by id
@@ -69,7 +69,7 @@ http://localhost:1337/restaurants/<restaurant_id>
 
 #### Get all reviews for a restaurant
 ```
-http://localhost:1337/reviews/?restaurant_id=<restaurant_id>
+http://localhost:1337/reviews?restaurant_id=<restaurant_id>
 ```
 
 #### Get all restaurant reviews
@@ -84,7 +84,7 @@ http://localhost:1337/reviews/<review_id>
 
 #### Get all reviews for a restaurant
 ```
-http://localhost:1337/reviews/?restaurant_id=<restaurant_id>
+http://localhost:1337/reviews?restaurant_id=<restaurant_id>
 ```
 
 
@@ -110,7 +110,7 @@ http://localhost:1337/reviews/
 
 #### Favorite a restaurant
 ```
-http://localhost:1337/restaurants/<restaurant_id>/?is_favorite=true
+http://localhost:1337/restaurants/<restaurant_id>?is_favorite=true
 ```
 
 #### Unfavorite a restaurant


### PR DESCRIPTION
When creating a postman representation of this API. I noticed a couple places where there was a / that was causing errors. I removed all slashes. I also made the curl call syntax match the rest of the page. 